### PR TITLE
Make use statement explicit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use ghash::{universal_hash::UniversalHash, GHash};
 
 mod ctr;
 
-use ctr::Ctr;
+use crate::ctr::Ctr;
 
 pub struct AesGcm<Aes>
 where


### PR DESCRIPTION
The current code does not compile with Rust 1.71.0

```
error[E0659]: `ctr` is ambiguous
 --> src/lib.rs:9:5
  |
9 | use ctr::Ctr;
  |     ^^^ ambiguous name
  |
  = note: ambiguous because of multiple potential import sources
  = note: `ctr` could refer to a crate passed with `--extern`
  = help: use `::ctr` to refer to this crate unambiguously
note: `ctr` could also refer to the module defined here
 --> src/lib.rs:7:1
  |
7 | mod ctr;
  | ^^^^^^^^
  = help: use `crate::ctr` to refer to this module unambiguously

For more information about this error, try `rustc --explain E0659`.
error: could not compile `aead-gcm-stream` (lib) due to previous error
```

This patch disambiguates the use statement for Rust versions before 1.72.0 (See [the rust PR here](https://github.com/rust-lang/rust/pull/112086/))