### PR TITLE
feat: support any iv length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,10 +141,14 @@ where
     if nonce.len() == 12 {
       nonce_block[..nonce.len()].copy_from_slice(nonce);
     } else {
+      // We calculate GHASH(nonce || padding || 0^64 || len_u64(nonce)) to get J0 (initial counter block)
+      // See NIST SP 800-38D, section 7.1, algorithm 4, step 2 or section 7.2, algorithm 5, step 3
+      // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
       let mut ghash = GHash::new(&ghash_key);
       ghash.update_padded(nonce);
       ghash.update_padded(&(8 * nonce.len() as u128).to_be_bytes());
       nonce_block.copy_from_slice(&ghash.finalize());
+      // We subtract 1 from the counter block to align with the CTR implementation below
       for i in nonce_block.iter_mut().rev() {
         *i = i.wrapping_sub(1);
         if *i != 0xff {

--- a/tests/aes128gcm.rs
+++ b/tests/aes128gcm.rs
@@ -3014,6 +3014,22 @@ TestVector {
     ciphertext: &hex!("ba59002df3394c5b80983519dc163eca5c44df80f8c4c4e15d3ff73f13c170c80a59d87a2165a7b450be01031a8e41c505c89f"),
     tag: &hex!("28418c564731bddf3d504d8ed32e66ee"),
 },
+TestVector {
+    key: &hex!("83f9d97d4ab759fddcc3ef54a0e2a8ec"),
+    nonce: &hex!("cf"),
+    plaintext: &hex!("77e6329cf9424f71c808df9170bfd298"),
+    aad: &hex!("6dd49eaeb4103dac8f97e3234946dd2d"),
+    ciphertext: &hex!("50de86a7a92a8a5ea33db5696b96cd77"),
+    tag: &hex!("aa181e84bc8b4bf5a68927c409d422cb"),
+},
+TestVector {
+    key: &hex!("ca91e2414409a439b06573d772f90afb"),
+    nonce: &hex!("177008f920a06169ccdf753a338553fefd46845869c9244da44997f83d4ce805a18707c84d114f9c68427b22841591e6caecf5c3e72a25167aa860c51bdc1aa56dcd69f29a2f35e70a322b9eba092a98d66a956b4d294383a0ebab26f7c4df1a5d4060dfc45a14155100ea7d9e32debb6537406b757291710505142e7659fc77"),
+    plaintext: &hex!("28003e30c4a4ca9e41aafefac1e1c3de"),
+    aad: &hex!("bfeb15fcf7b15f0e14c04439b67950bd"),
+    ciphertext: &hex!("00e472971f3a7770aa7158fd92f17bb7"),
+    tag: &hex!("16661b85eb51646c94cf2be4e42d7a8e"),
+},
 ];
 
 #[test]

--- a/tests/aes256gcm.rs
+++ b/tests/aes256gcm.rs
@@ -3014,6 +3014,22 @@ const TEST_VECTORS: &[TestVector<[u8; 32]>] = &[
         ciphertext: &hex!("488b40ad594e1845ccdd9e9467fc5e1afbbfde34e57d45bfcd30b61cc326d57fe8e3f31a39cdebf00f60bbd2c3cdf69f756eff"),
         tag: &hex!("3bf3fbab9b48486fd08a5552604df639"),
     },
+    TestVector {
+        key: &hex!("bb4635d766dd0e4a7019d1724c736e1f2c016af9e29e7d3aa2c0de23e780af26"),
+        nonce: &hex!("ab"),
+        plaintext: &hex!("d05ce878d94662d1520b184b4bef3c45"),
+        aad: &hex!("0f85c7dbeb674b7a70c35125d3619350"),
+        ciphertext: &hex!("51baa26a6a719c1600645ff3bfdfa53b"),
+        tag: &hex!("6bd54e5184eb300934b392c32b7c1a6e"),
+    },
+    TestVector {
+        key: &hex!("fcbc7eb62716dc7f792b6194d26d6d569eaee07a9d3c37ca42854090661e1845"),
+        nonce: &hex!("4c8c4624279b23b495c788844c76d225ebf23826599c3e1cf4db1da2d65a7f7544d8e86fcc33fb113d3174b8c7903122cb5967f6107382cc5ac6e7a0e4ca4f08de3e911d483e68253d3f886cfe349bf93299a28e665bc096a51ce84ce6940b34a037722483b96a7b25507f5a04643c6730faaab618e6231a727714d6f366fa9b"),
+        plaintext: &hex!("22144fc12f7bc5522b88b76c8ded1c76"),
+        aad: &hex!("3c182af19c46ff4acbdacecf70b42fb5"),
+        ciphertext: &hex!("c8d98107c0cb3c0fd2189ae97280d562"),
+        tag: &hex!("2906772330ecd9a3b8a82876a4ebdeea"),
+    },
 ];
 
 #[test]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
 pub struct TestVector<K: 'static> {
   pub key: &'static K,
-  pub nonce: &'static [u8; 12],
+  pub nonce: &'static [u8],
   pub aad: &'static [u8],
   pub plaintext: &'static [u8],
   pub ciphertext: &'static [u8],


### PR DESCRIPTION
This PR adds support of IV of any length.

The implementation follows section 7.1, algorithm 4, step 2 or section 7.2, algorithm 5, step 3 of the spec (ref: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf )

Test cases are taken from https://raw.githubusercontent.com/wg/crypto/refs/heads/master/src/test/resources/nist/gcmEncryptExtIV128.rsp and https://raw.githubusercontent.com/wg/crypto/refs/heads/master/src/test/resources/nist/gcmEncryptExtIV256.rsp

related: denoland/deno#27441